### PR TITLE
Add garment options mapping

### DIFF
--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -19,8 +19,13 @@ const DEFECT_OPTIONS = [
   { id: 'button', label: 'Saknar knapp' },
 ];
 
+// Map each selectable product type to the image set used when
+// marking damages. Multiple options share the same image based on
+// the garment category.
 const typeImages = {
-  overdel: { front: upperBodyImg },
+  undertröja: { front: upperBodyImg },
+  tröja: { front: upperBodyImg },
+  ytterplagg: { front: upperBodyImg },
   nederdel: { front: lowerBodyImg },
   skor: null,
 };

--- a/src/components/order/ProductSelectionStep.jsx
+++ b/src/components/order/ProductSelectionStep.jsx
@@ -38,7 +38,9 @@ export default function ProductSelectionStep({
   };
 
   const updateProduct = (id, field, value) => {
-    setProducts(products.map(p => (p.id === id ? { ...p, [field]: value } : p)));
+    setProducts(prev =>
+      prev.map(p => (p.id === id ? { ...p, [field]: value } : p))
+    );
   };
 
   return (

--- a/src/components/order/ProductTypeSelector.jsx
+++ b/src/components/order/ProductTypeSelector.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 
+// Available garment options. These are more fine grained than the
+// categories used internally when displaying the garment images.
+// "Undertröja", "Tröja" and "Ytterplagg" should all be treated as
+// upper body garments, "Nederdel" as a lower body garment and
+// "Skor" represents footwear.
 const OPTIONS = [
-  { value: 'overdel', label: 'Överdel' },
+  { value: 'undertröja', label: 'Undertröja' },
+  { value: 'tröja', label: 'Tröja' },
+  { value: 'ytterplagg', label: 'Ytterplagg' },
   { value: 'nederdel', label: 'Nederdel' },
   { value: 'skor', label: 'Skor' },
 ];


### PR DESCRIPTION
## Summary
- add extended product options
- map new options to existing images
- fix field updates so selecting a type persists

## Testing
- `npm run build` *(fails: vite not found)*