### PR TITLE
Use config data for repair form

### DIFF
--- a/src/components/OrderForm.jsx
+++ b/src/components/OrderForm.jsx
@@ -12,6 +12,7 @@ const createEmptyProduct = (id) => ({
   otherIssues: {},
   defectDetails: {},
   defectLabels: {},
+  images: null,
   isEmployeeOwned: false,
   employeeName: '',
   employeeDepartment: '',

--- a/src/components/order/DamageSelector.jsx
+++ b/src/components/order/DamageSelector.jsx
@@ -3,12 +3,13 @@ import React from 'react';
 export default function DamageSelector({
   index = 0,
   damage = '',
-  tearSize = '',
-  options = [],
+  option = '',
+  damageOptions = [],
+  optionOptions = [],
   onDamageChange,
-  onTearSizeChange,
+  onOptionChange,
   damageError = null,
-  tearSizeError = null,
+  optionError = null,
 }) {
   return (
     <div className="border border-gray-200 p-3 rounded-md space-y-3 relative">
@@ -25,7 +26,7 @@ export default function DamageSelector({
             className={damageError ? 'border-red-500' : ''}
           >
             <option value="">Välj typ av skada</option>
-            {options.map((opt) => (
+            {damageOptions.map((opt) => (
               <option key={opt.value || opt.id} value={opt.value || opt.id}>
                 {opt.label}
               </option>
@@ -33,44 +34,22 @@ export default function DamageSelector({
           </select>
           {damageError && <p className="text-sm text-red-500 mt-1">{damageError}</p>}
         </div>
-        {damage === 'tear' && (
+        {optionOptions.length > 0 && (
           <div>
-            <label className="text-sm font-medium">
-              Storlek <span className="text-red-500">*</span>
-            </label>
-            <div className={tearSizeError ? 'mt-1 border border-red-500 rounded-md p-2' : 'mt-1 p-2'}>
-              <div className="flex items-center space-x-2">
-                <input
-                  type="radio"
-                  id={`tear-small-${index}`}
-                  value="small"
-                  checked={tearSize === 'small'}
-                  onChange={(e) => onTearSizeChange && onTearSizeChange(e.target.value)}
-                />
-                <label htmlFor={`tear-small-${index}`}>Max 5 cm</label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <input
-                  type="radio"
-                  id={`tear-medium-${index}`}
-                  value="medium"
-                  checked={tearSize === 'medium'}
-                  onChange={(e) => onTearSizeChange && onTearSizeChange(e.target.value)}
-                />
-                <label htmlFor={`tear-medium-${index}`}>6-15 cm</label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <input
-                  type="radio"
-                  id={`tear-large-${index}`}
-                  value="large"
-                  checked={tearSize === 'large'}
-                  onChange={(e) => onTearSizeChange && onTearSizeChange(e.target.value)}
-                />
-                <label htmlFor={`tear-large-${index}`}>16 cm+</label>
-              </div>
-            </div>
-            {tearSizeError && <p className="text-sm text-red-500 mt-1">{tearSizeError}</p>}
+            <label className="text-sm font-medium">Alternativ</label>
+            <select
+              value={option}
+              onChange={(e) => onOptionChange && onOptionChange(e.target.value)}
+              className={optionError ? 'border-red-500' : ''}
+            >
+              <option value="">Välj</option>
+              {optionOptions.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            {optionError && <p className="text-sm text-red-500 mt-1">{optionError}</p>}
           </div>
         )}
       </div>

--- a/src/components/order/PriceSummary.jsx
+++ b/src/components/order/PriceSummary.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import config from '../config.js';
+import config from '../../config.js';
 
 const getPrice = (pricing = {}, count) => {
   if (count >= 6) return pricing['10'] || 0;

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -43,6 +43,16 @@ export default function ProductCard({ product, onUpdate }) {
     const details = { ...(product.damageDetails || {}) };
     details[`damage-${idx}`] = { optionId: '' };
     updateField('damageDetails', details);
+    const damageObj = category?.damages.find((d) => d.id === val);
+    if (damageObj && damageObj.picturesToBeMarked?.length) {
+      const pics = damageObj.picturesToBeMarked;
+      updateField('images', {
+        front: pics[0] || null,
+        back: pics[1] || pics[0] || null,
+        left: pics[2] || pics[0] || null,
+        right: pics[3] || pics[0] || null,
+      });
+    }
   };
 
   const updateDamageDetail = (idx, detail) => {

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -5,21 +5,19 @@ import DamageSelector from './DamageSelector';
 import DefectsSection from './DefectsSection';
 import EmployeeOwnershipFields from './EmployeeOwnershipFields';
 import GarmentDamageMarker from './damage-marker/GarmentDamageMarker';
-
-const DAMAGE_OPTIONS = [
-  { value: 'tear', label: 'Reva' },
-  { value: 'hole', label: 'H\xE5l' },
-  { value: 'stain', label: 'Fl\xE4ck' },
-];
-
-const DEFECT_OPTIONS = [
-  { id: 'zipper', label: 'Trasig dragkedja' },
-  { id: 'button', label: 'Saknar knapp' },
-];
+import config from '../config.js';
 
 export default function ProductCard({ product, onUpdate }) {
   const [selectedDamageIndex, setSelectedDamageIndex] = useState();
   const [selectedDefectId, setSelectedDefectId] = useState();
+
+  const category = config.productCategories.find((c) => c.id === product.type);
+  const DAMAGE_OPTIONS = category
+    ? category.damages.map((d) => ({ id: d.id, label: d.name.sv || d.name.en, options: d.options || [] }))
+    : [];
+  const DEFECT_OPTIONS = category
+    ? category.defects.map((d) => ({ id: d.id, label: d.name.sv || d.name.en }))
+    : [];
 
   const updateField = (field, value) => {
     onUpdate && onUpdate(product.id, field, value);
@@ -42,6 +40,9 @@ export default function ProductCard({ product, onUpdate }) {
     const arr = [...(product.damages || [])];
     arr[idx] = val;
     updateField('damages', arr);
+    const details = { ...(product.damageDetails || {}) };
+    details[`damage-${idx}`] = { optionId: '' };
+    updateField('damageDetails', details);
   };
 
   const updateDamageDetail = (idx, detail) => {
@@ -96,10 +97,13 @@ export default function ProductCard({ product, onUpdate }) {
                 <DamageSelector
                   index={idx}
                   damage={product.damages?.[idx] || ''}
-                  tearSize={product.damageDetails?.[`damage-${idx}`]?.tearSize || ''}
-                  options={DAMAGE_OPTIONS}
+                  option={product.damageDetails?.[`damage-${idx}`]?.optionId || ''}
+                  damageOptions={DAMAGE_OPTIONS}
+                  optionOptions={
+                    DAMAGE_OPTIONS.find((d) => d.id === (product.damages?.[idx] || ''))?.options || []
+                  }
                   onDamageChange={(val) => updateDamageType(idx, val)}
-                  onTearSizeChange={(val) => updateDamageDetail(idx, { tearSize: val })}
+                  onOptionChange={(val) => updateDamageDetail(idx, { optionId: val })}
                 />
                 <button
                   type="button"

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -5,7 +5,7 @@ import DamageSelector from './DamageSelector';
 import DefectsSection from './DefectsSection';
 import EmployeeOwnershipFields from './EmployeeOwnershipFields';
 import GarmentDamageMarker from './damage-marker/GarmentDamageMarker';
-import config from '../config.js';
+import config from '../../config.js';
 
 export default function ProductCard({ product, onUpdate }) {
   const [selectedDamageIndex, setSelectedDamageIndex] = useState();

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -36,6 +36,24 @@ export default function ProductCard({ product, onUpdate }) {
     }
   }, [product.damageCount]);
 
+  // When the product type changes ensure a default image is available so
+  // the user can start marking damages immediately. We use the first
+  // damage's picture set as a fallback if no specific image has been
+  // selected yet.
+  useEffect(() => {
+    if (!product.images && category && category.damages.length > 0) {
+      const pics = category.damages[0].picturesToBeMarked || [];
+      if (pics.length) {
+        updateField('images', {
+          front: pics[0] || null,
+          back: pics[1] || pics[0] || null,
+          left: pics[2] || pics[0] || null,
+          right: pics[3] || pics[0] || null,
+        });
+      }
+    }
+  }, [product.type]);
+
   const updateDamageType = (idx, val) => {
     const arr = [...(product.damages || [])];
     arr[idx] = val;

--- a/src/components/order/ProductSelectionStep.jsx
+++ b/src/components/order/ProductSelectionStep.jsx
@@ -23,6 +23,7 @@ export default function ProductSelectionStep({
         otherIssues: {},
         defectDetails: {},
         defectLabels: {},
+        images: null,
         isEmployeeOwned: false,
         employeeName: '',
         employeeDepartment: '',

--- a/src/components/order/ProductTypeSelector.jsx
+++ b/src/components/order/ProductTypeSelector.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
+import config from '../config.js';
 
-const OPTIONS = [
-  { value: 'undertröja', label: 'Undertröja' },
-  { value: 'tröja', label: 'Tröja' },
-  { value: 'ytterplagg', label: 'Ytterplagg' },
-  { value: 'nederdel', label: 'Nederdel' },
-  { value: 'skor', label: 'Skor' },
-];
+const OPTIONS = config.productCategories.map((cat) => ({
+  value: cat.id,
+  label: cat.name.sv || cat.name.en,
+}));
 
 export default function ProductTypeSelector({ productType, onTypeChange, onOpenChange, error }) {
   const handleChange = (e) => {

--- a/src/components/order/ProductTypeSelector.jsx
+++ b/src/components/order/ProductTypeSelector.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import config from '../config.js';
+import config from '../../config.js';
 
 const OPTIONS = config.productCategories.map((cat) => ({
   value: cat.id,

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,2 @@
-import config from '../.mvp/config.json';
+import config from '../.mvp/config.json' assert { type: 'json' };
 export default config;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,2 @@
+import config from '../.mvp/config.json';
+export default config;

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,5 @@
-import config from '../.mvp/config.json' assert { type: 'json' };
+// Central place for runtime configuration used across the UI.
+// Using the `with` import attribute keeps Node and Vite happy
+// when loading JSON as a module.
+import config from '../.mvp/config.json' with { type: 'json' };
 export default config;


### PR DESCRIPTION
## Summary
- centralize config from `.mvp/config.json`
- populate product type selector from config
- load damages/defects dynamically per product
- compute prices based on config pricing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842156436ec832cbc5768b29afb25f4