### PR TITLE
Use config texts for first step

### DIFF
--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -6,6 +6,7 @@ import DefectsSection from './DefectsSection';
 import EmployeeOwnershipFields from './EmployeeOwnershipFields';
 import GarmentDamageMarker from './damage-marker/GarmentDamageMarker';
 import config from '../../config.js';
+import t from '../../i18n.js';
 
 export default function ProductCard({ product, onUpdate }) {
   const [selectedDamageIndex, setSelectedDamageIndex] = useState();
@@ -106,7 +107,7 @@ export default function ProductCard({ product, onUpdate }) {
   return (
     <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg mb-6">
       <div className="flex justify-between items-center mb-3">
-        <h3 className="text-lg font-medium">Produkt #{product.id}</h3>
+        <h3 className="text-lg font-medium">{t('firstStep.product')} #{product.id}</h3>
       </div>
       <div className="space-y-6">
         <ProductTypeSelector

--- a/src/components/order/ProductQuantitySelector.jsx
+++ b/src/components/order/ProductQuantitySelector.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import t from '../../i18n.js';
 
 function MinusIcon({className}) {
   return (
@@ -28,7 +29,7 @@ export default function ProductQuantitySelector({ quantity, onIncrease, onDecrea
     <div className="space-y-2">
       <div className="flex justify-between items-center">
         <label htmlFor="quantity" className="font-medium">
-          Hur många produkter gäller det? <span className="text-red-500">*</span>
+          {t('firstStep.selectNumberOfProducts')} <span className="text-red-500">*</span>
         </label>
       </div>
       <div className="flex items-center justify-between w-full max-w-md h-14 rounded-lg border border-input overflow-hidden bg-white">

--- a/src/components/order/ProductSelectionStep.jsx
+++ b/src/components/order/ProductSelectionStep.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ProductQuantitySelector from './ProductQuantitySelector';
 import ProductCard from './ProductCard';
 import PriceSummary from './PriceSummary';
+import t from '../../i18n.js';
 
 export default function ProductSelectionStep({
   products,
@@ -50,10 +51,9 @@ export default function ProductSelectionStep({
   return (
     <div className="space-y-4">
       <div className="space-y-4 mb-6">
-        <p>
-          Välkommen! Här kan du enkelt beställa lagning & återställning av dina arbetskläder.
-          Tänk på att inte skicka in klassificerade skyddskläder och skyddsskor.
-        </p>
+        <h2 className="text-xl md:text-2xl font-bold">{t('firstStep.title')}</h2>
+        <p>{t('firstStep.instruction')}</p>
+        <p className="text-sm text-gray-700">{t('firstStep.reminder')}</p>
         <ProductQuantitySelector
           quantity={quantity}
           onIncrease={addProduct}
@@ -74,7 +74,7 @@ export default function ProductSelectionStep({
         onClick={nextStep}
         className="w-full rounded-full h-12 bg-[#262E85] hover:bg-[#1e2566] text-white"
       >
-        Nästa
+        {t('firstStep.next')}
       </button>
     </div>
   );

--- a/src/components/order/ProductTypeSelector.jsx
+++ b/src/components/order/ProductTypeSelector.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import config from '../../config.js';
+import t from '../../i18n.js';
 
 const OPTIONS = config.productCategories.map((cat) => ({
   value: cat.id,
@@ -14,13 +15,13 @@ export default function ProductTypeSelector({ productType, onTypeChange, onOpenC
 
   return (
     <div className="space-y-2">
-      <label className="font-medium">Välj typ av produkt <span className="text-red-500">*</span></label>
+      <label className="font-medium">{t('firstStep.selectTypeOfProduct')} <span className="text-red-500">*</span></label>
       <select
         className={`w-full h-10 rounded border px-3 ${error ? 'border-red-500' : ''}`}
         value={productType || ''}
         onChange={handleChange}
       >
-        <option value="" disabled>Välj</option>
+        <option value="" disabled>{t('firstStep.select')}</option>
         {OPTIONS.map(opt => (
           <option key={opt.value} value={opt.value}>{opt.label}</option>
         ))}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,16 @@
+import config from './config.js';
+
+const LANGUAGE = 'se';
+
+export function t(path) {
+  const parts = path.split('.');
+  let obj = config.texts;
+  for (const part of parts) {
+    obj = obj?.[part];
+    if (obj === undefined) return path;
+  }
+  if (typeof obj === 'string') return obj;
+  return obj?.[LANGUAGE] || obj?.sv || obj?.se || obj?.en || '';
+}
+
+export default t;


### PR DESCRIPTION
## Summary
- add `i18n.js` helper to fetch texts from config
- apply translation texts to initial order step

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684372689b48832cba186344f26831de