### PR TITLE
Refine modal UX and marker functionality

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -62,7 +62,7 @@ export default function Banner({ prefilledData = null, isOpen, onOpenChange }) {
           <div className="flex-1 overflow-auto">
             <OrderForm prefilledData={prefilledData} />
           </div>
-          <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground" />
+          <DialogClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground p-2 text-xl" />
         </DialogContent>
       </Dialog>
     </div>

--- a/src/components/order/DamageSelector.jsx
+++ b/src/components/order/DamageSelector.jsx
@@ -31,7 +31,8 @@ export default function DamageSelector({
           <select
             value={damage}
             onChange={handleDamageChange}
-            className={`w-full h-10 rounded border px-3 pr-8 ${damageError ? 'border-red-500' : 'border-gray-300'}`}
+            className={`w-full h-10 rounded border px-3 pr-10 ${damageError ? 'border-red-500' : 'border-gray-300'}`}
+            required
           >
             <option value="">Välj typ av skada</option>
             {damageOptions.map((opt) => (
@@ -48,7 +49,7 @@ export default function DamageSelector({
             <select
               value={option}
               onChange={handleOptionChange}
-              className={`w-full h-10 rounded border px-3 pr-8 ${optionError ? 'border-red-500' : 'border-gray-300'}`}
+              className={`w-full h-10 rounded border px-3 pr-10 ${optionError ? 'border-red-500' : 'border-gray-300'}`}
             >
               <option value="">Välj</option>
               {optionOptions.map((opt) => (

--- a/src/components/order/OrderInformationStep.jsx
+++ b/src/components/order/OrderInformationStep.jsx
@@ -185,10 +185,12 @@ export default function OrderInformationStep({
           </div>
         </div>
 
-        <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg">
-          <h3 className="text-lg font-medium mb-3">{t('thirdStep.summary')}</h3>
-          <PriceSummary products={products} />
-        </div>
+        {products.some(p => p.type) && (
+          <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg">
+            <h3 className="text-lg font-medium mb-3">{t('thirdStep.summary')}</h3>
+            <PriceSummary products={products} />
+          </div>
+        )}
 
         <div className="flex items-start space-x-2 mb-6">
           <input

--- a/src/components/order/OrderInformationStep.jsx
+++ b/src/components/order/OrderInformationStep.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PriceSummary from '../order/PriceSummary.jsx';
+import t from '../../i18n.js';
 
 export default function OrderInformationStep({
   orderInfo = {},
@@ -26,33 +27,31 @@ export default function OrderInformationStep({
   return (
     <div>
       <div className="flex items-center mb-4">
-        <h2 className="text-xl md:text-2xl font-bold">
-          Beställ lagning & återställning av arbetskläder
-        </h2>
+        <h2 className="text-xl md:text-2xl font-bold">{t('thirdStep.title')}</h2>
       </div>
       <div className="flex mb-4">
         <button type="button" onClick={prevStep} className="text-[#262E85] hover:underline">
-          Tillbaka
+          {t('thirdStep.back')}
         </button>
       </div>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg">
-          <h3 className="text-lg font-medium mb-3">Orderinformation</h3>
+          <h3 className="text-lg font-medium mb-3">{t('thirdStep.orderInformation')}</h3>
           <div className="space-y-4">
             <div>
-              <label className="font-medium block mb-2">Kundnummer</label>
+              <label className="font-medium block mb-2">{t('thirdStep.customerNumber')}</label>
               <input
-                placeholder="Ange kundnummer"
+                placeholder={t('thirdStep.enterCustomerNumber')}
                 value={orderInfo.customerNumber || ''}
                 onChange={(e) => onChange && onChange('customerNumber', e.target.value)}
               />
             </div>
             <div>
               <label className="font-medium block mb-2">
-                Företagsnamn <span className="text-red-500">*</span>
+                {t('thirdStep.companyName')} <span className="text-red-500">*</span>
               </label>
               <input
-                placeholder="Ange företagsnamn"
+                placeholder={t('thirdStep.enterCompanyName')}
                 value={orderInfo.companyName || ''}
                 onChange={(e) => onChange && onChange('companyName', e.target.value)}
                 onBlur={() => onFieldBlur && onFieldBlur('companyName')}
@@ -65,10 +64,10 @@ export default function OrderInformationStep({
             </div>
             <div>
               <label className="font-medium block mb-2">
-                Namn på beställare <span className="text-red-500">*</span>
+                {t('thirdStep.ordererName')} <span className="text-red-500">*</span>
               </label>
               <input
-                placeholder="Ange beställare"
+                placeholder={t('thirdStep.enterOrdererName')}
                 value={orderInfo.ordererName || ''}
                 onChange={(e) => onChange && onChange('ordererName', e.target.value)}
                 onBlur={() => onFieldBlur && onFieldBlur('ordererName')}
@@ -81,10 +80,10 @@ export default function OrderInformationStep({
             </div>
             <div>
               <label className="font-medium block mb-2">
-                Telefon <span className="text-red-500">*</span>
+                {t('thirdStep.phone')} <span className="text-red-500">*</span>
               </label>
               <input
-                placeholder="Ange telefon"
+                placeholder={t('thirdStep.enterPhone')}
                 value={orderInfo.phone || ''}
                 onChange={(e) => onChange && onChange('phone', e.target.value)}
                 onBlur={() => onFieldBlur && onFieldBlur('phone')}
@@ -97,10 +96,10 @@ export default function OrderInformationStep({
             </div>
             <div>
               <label className="font-medium block mb-2">
-                E-post <span className="text-red-500">*</span>
+                {t('thirdStep.email')} <span className="text-red-500">*</span>
               </label>
               <input
-                placeholder="Ange e-post"
+                placeholder={t('thirdStep.enterEmail')}
                 value={orderInfo.email || ''}
                 onChange={(e) => onChange && onChange('email', e.target.value)}
                 onBlur={() => onFieldBlur && onFieldBlur('email')}
@@ -115,14 +114,14 @@ export default function OrderInformationStep({
         </div>
 
         <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg">
-          <h3 className="text-lg font-medium mb-3">Faktureringsadress</h3>
+          <h3 className="text-lg font-medium mb-3">{t('thirdStep.billingAddress')}</h3>
           <div className="space-y-4">
             <div>
               <label className="font-medium block mb-2">
-                Företagsnamn <span className="text-red-500">*</span>
+                {t('thirdStep.companyName')} <span className="text-red-500">*</span>
               </label>
               <input
-                placeholder="Ange företagsnamn"
+                placeholder={t('thirdStep.enterCompanyName')}
                 value={orderInfo.billingCompanyName || ''}
                 onChange={(e) => onChange && onChange('billingCompanyName', e.target.value)}
                 onBlur={() => onFieldBlur && onFieldBlur('billingCompanyName')}
@@ -135,10 +134,10 @@ export default function OrderInformationStep({
             </div>
             <div>
               <label className="font-medium block mb-2">
-                Gatuadress <span className="text-red-500">*</span>
+                {t('thirdStep.streetAddress')} <span className="text-red-500">*</span>
               </label>
               <input
-                placeholder="Ange gatuadress"
+                placeholder={t('thirdStep.enterStreetAddress')}
                 value={orderInfo.billingStreet || ''}
                 onChange={(e) => onChange && onChange('billingStreet', e.target.value)}
                 onBlur={() => onFieldBlur && onFieldBlur('billingStreet')}
@@ -152,10 +151,10 @@ export default function OrderInformationStep({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="font-medium block mb-2">
-                  Postnummer <span className="text-red-500">*</span>
+                  {t('thirdStep.postalCode')} <span className="text-red-500">*</span>
                 </label>
                 <input
-                  placeholder="Ange postnummer"
+                  placeholder={t('thirdStep.enterPostalCode')}
                   value={orderInfo.billingZipCode || ''}
                   onChange={(e) => onChange && onChange('billingZipCode', e.target.value)}
                   onBlur={() => onFieldBlur && onFieldBlur('billingZipCode')}
@@ -168,10 +167,10 @@ export default function OrderInformationStep({
               </div>
               <div>
                 <label className="font-medium block mb-2">
-                  Ort <span className="text-red-500">*</span>
+                  {t('thirdStep.city')} <span className="text-red-500">*</span>
                 </label>
                 <input
-                  placeholder="Ange ort"
+                  placeholder={t('thirdStep.enterCity')}
                   value={orderInfo.billingCity || ''}
                   onChange={(e) => onChange && onChange('billingCity', e.target.value)}
                   onBlur={() => onFieldBlur && onFieldBlur('billingCity')}
@@ -186,7 +185,10 @@ export default function OrderInformationStep({
           </div>
         </div>
 
-        <PriceSummary products={products} />
+        <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg">
+          <h3 className="text-lg font-medium mb-3">{t('thirdStep.summary')}</h3>
+          <PriceSummary products={products} />
+        </div>
 
         <div className="flex items-start space-x-2 mb-6">
           <input
@@ -198,7 +200,7 @@ export default function OrderInformationStep({
             className={fieldError('termsAccepted') ? 'border-red-500' : ''}
           />
           <label htmlFor="termsAccepted" className="text-sm cursor-pointer">
-            Jag accepterar villkoren <span className="text-red-500">*</span>
+            {t('thirdStep.acceptTerms')} <span className="text-red-500">*</span>
           </label>
         </div>
         {fieldError('termsAccepted') && (
@@ -206,7 +208,7 @@ export default function OrderInformationStep({
         )}
 
         <button type="submit" className="w-full rounded-full h-12 bg-[#262E85] hover:bg-[#1e2566]">
-          Skicka
+          {t('thirdStep.order')}
         </button>
       </form>
     </div>

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -12,6 +12,8 @@ export default function ProductCard({ product, onUpdate }) {
   const [selectedDamageIndex, setSelectedDamageIndex] = useState();
   const [selectedDefectId, setSelectedDefectId] = useState();
   const [markingOpen, setMarkingOpen] = useState(false);
+  const [damageMarkable, setDamageMarkable] = useState({});
+  const [defectMarkable, setDefectMarkable] = useState({});
 
   const category = config.productCategories.find((c) => c.id === product.type);
 
@@ -68,6 +70,21 @@ export default function ProductCard({ product, onUpdate }) {
       }
     }
   }, [product.type, category]);
+
+  useEffect(() => {
+    const dMark = {};
+    product.damages.forEach((id, idx) => {
+      const cfg = DAMAGE_OPTIONS.find((o) => o.id === id);
+      dMark[idx] = !!cfg?.markedOnPicture;
+    });
+    setDamageMarkable(dMark);
+
+    const defMark = {};
+    DEFECT_OPTIONS.forEach((opt) => {
+      defMark[opt.id] = !!opt.markedOnPicture;
+    });
+    setDefectMarkable(defMark);
+  }, [product.damages, category]);
 
   const updateDamageType = (idx, val) => {
     const arr = [...(product.damages || [])];
@@ -198,15 +215,21 @@ export default function ProductCard({ product, onUpdate }) {
                   updateField('defectDetails', details);
                 }}
                 onSelectDamage={(idx) => {
-                  setSelectedDefectId(undefined);
-                  setSelectedDamageIndex(idx);
-                  setMarkingOpen(true);
+                  if (damageMarkable[idx]) {
+                    setSelectedDefectId(undefined);
+                    setSelectedDamageIndex(idx);
+                    setMarkingOpen(true);
+                  }
                 }}
                 onSelectDefect={(id) => {
-                  setSelectedDamageIndex(undefined);
-                  setSelectedDefectId(id);
-                  setMarkingOpen(true);
+                  if (defectMarkable[id]) {
+                    setSelectedDamageIndex(undefined);
+                    setSelectedDefectId(id);
+                    setMarkingOpen(true);
+                  }
                 }}
+                damageMarkable={damageMarkable}
+                defectMarkable={defectMarkable}
               />
             </div>
           )}

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -12,8 +12,6 @@ export default function ProductCard({ product, onUpdate }) {
   const [selectedDamageIndex, setSelectedDamageIndex] = useState();
   const [selectedDefectId, setSelectedDefectId] = useState();
   const [markingOpen, setMarkingOpen] = useState(false);
-  const [damageMarkable, setDamageMarkable] = useState({});
-  const [defectMarkable, setDefectMarkable] = useState({});
 
   const category = config.productCategories.find((c) => c.id === product.type);
 
@@ -39,20 +37,6 @@ export default function ProductCard({ product, onUpdate }) {
       }))
     : [];
 
-  useEffect(() => {
-    const dMark = {};
-    product.damages.forEach((id, idx) => {
-      const cfg = DAMAGE_OPTIONS.find((o) => o.id === id);
-      dMark[idx] = !!cfg?.markedOnPicture;
-    });
-    setDamageMarkable(dMark);
-
-    const defMark = {};
-    DEFECT_OPTIONS.forEach((opt) => {
-      defMark[opt.id] = !!opt.markedOnPicture;
-    });
-    setDefectMarkable(defMark);
-  }, [product.damages, category]);
 
   const updateField = (field, value) => {
     onUpdate && onUpdate(product.id, field, value);
@@ -214,21 +198,15 @@ export default function ProductCard({ product, onUpdate }) {
                   updateField('defectDetails', details);
                 }}
                 onSelectDamage={(idx) => {
-                  if (damageMarkable[idx]) {
-                    setSelectedDefectId(undefined);
-                    setSelectedDamageIndex(idx);
-                    setMarkingOpen(true);
-                  }
+                  setSelectedDefectId(undefined);
+                  setSelectedDamageIndex(idx);
+                  setMarkingOpen(true);
                 }}
                 onSelectDefect={(id) => {
-                  if (defectMarkable[id]) {
-                    setSelectedDamageIndex(undefined);
-                    setSelectedDefectId(id);
-                    setMarkingOpen(true);
-                  }
+                  setSelectedDamageIndex(undefined);
+                  setSelectedDefectId(id);
+                  setMarkingOpen(true);
                 }}
-                damageMarkable={damageMarkable}
-                defectMarkable={defectMarkable}
               />
             </div>
           )}

--- a/src/components/order/ProductSelectionStep.jsx
+++ b/src/components/order/ProductSelectionStep.jsx
@@ -64,7 +64,7 @@ export default function ProductSelectionStep({
       {products.map(p => (
         <ProductCard key={p.id} product={p} onUpdate={updateProduct} />
       ))}
-      {products.length > 0 && (
+      {products.some(p => p.type) && (
         <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg mb-6">
           <h3 className="text-lg font-medium mb-3">{t('firstStep.summary')}</h3>
           <PriceSummary products={products} />

--- a/src/components/order/ProductTypeSelector.jsx
+++ b/src/components/order/ProductTypeSelector.jsx
@@ -17,9 +17,10 @@ export default function ProductTypeSelector({ productType, onTypeChange, onOpenC
     <div className="space-y-2">
       <label className="font-medium">{t('firstStep.selectTypeOfProduct')} <span className="text-red-500">*</span></label>
       <select
-        className={`w-full h-10 rounded border px-3 pr-8 ${error ? 'border-red-500' : ''}`}
+        className={`w-full h-10 rounded border px-3 pr-10 ${error ? 'border-red-500' : ''}`}
         value={productType || ''}
         onChange={handleChange}
+        required
       >
         <option value="" disabled>{t('firstStep.select')}</option>
         {OPTIONS.map(opt => (

--- a/src/components/order/damage-marker/GarmentDamageMarker.jsx
+++ b/src/components/order/damage-marker/GarmentDamageMarker.jsx
@@ -14,6 +14,8 @@ export default function GarmentDamageMarker({
   selectedDefectId,
   onSelectDamage,
   onSelectDefect,
+  damageMarkable = {},
+  defectMarkable = {},
 }) {
   const [damagePositions, setDamagePositions] = useState({});
   const [defectPositions, setDefectPositions] = useState({});
@@ -63,7 +65,7 @@ export default function GarmentDamageMarker({
   };
 
   const handleMark = (x, y, view) => {
-    if (damageIndex !== undefined) {
+    if (damageIndex !== undefined && damageMarkable[damageIndex]) {
       const pos = { x, y, view };
       setDamagePositions((p) => ({ ...p, [damageIndex]: pos }));
       const orderKey = `damage-${damageIndex}`;
@@ -74,7 +76,7 @@ export default function GarmentDamageMarker({
       updateDamageDetail && updateDamageDetail(damageIndex, { position: pos, orderIndex: orderMap[orderKey] || nextOrder });
       return;
     }
-    if (defectId) {
+    if (defectId && defectMarkable[defectId]) {
       const pos = { x, y, view };
       setDefectPositions((p) => ({ ...p, [defectId]: pos }));
       if (!orderMap[defectId]) {
@@ -114,10 +116,10 @@ export default function GarmentDamageMarker({
   const totalMarks = Object.keys(damagePositions).length + Object.keys(defectPositions).length;
 
   const handleMarkerClick = (type, id) => {
-    if (type === 'damage' && onSelectDamage) {
+    if (type === 'damage' && onSelectDamage && damageMarkable[id]) {
       onSelectDamage(id);
     }
-    if (type === 'defect' && onSelectDefect) {
+    if (type === 'defect' && onSelectDefect && defectMarkable[id]) {
       onSelectDefect(id);
     }
   };
@@ -131,6 +133,8 @@ export default function GarmentDamageMarker({
           damagePositions={damagePositions}
           defectPositions={defectPositions}
           isWholeProductMarker={isWholeMarker}
+          damageMarkable={damageMarkable}
+          defectMarkable={defectMarkable}
           removeDamage={(e, idx) => {
             e.stopPropagation();
             setDamagePositions((p) => {

--- a/src/components/order/damage-marker/GarmentDamageMarker.jsx
+++ b/src/components/order/damage-marker/GarmentDamageMarker.jsx
@@ -14,8 +14,6 @@ export default function GarmentDamageMarker({
   selectedDefectId,
   onSelectDamage,
   onSelectDefect,
-  damageMarkable = {},
-  defectMarkable = {},
 }) {
   const [damagePositions, setDamagePositions] = useState({});
   const [defectPositions, setDefectPositions] = useState({});
@@ -65,7 +63,7 @@ export default function GarmentDamageMarker({
   };
 
   const handleMark = (x, y, view) => {
-    if (damageIndex !== undefined && damageMarkable[damageIndex]) {
+    if (damageIndex !== undefined) {
       const pos = { x, y, view };
       setDamagePositions((p) => ({ ...p, [damageIndex]: pos }));
       const orderKey = `damage-${damageIndex}`;
@@ -76,7 +74,7 @@ export default function GarmentDamageMarker({
       updateDamageDetail && updateDamageDetail(damageIndex, { position: pos, orderIndex: orderMap[orderKey] || nextOrder });
       return;
     }
-    if (defectId && defectMarkable[defectId]) {
+    if (defectId) {
       const pos = { x, y, view };
       setDefectPositions((p) => ({ ...p, [defectId]: pos }));
       if (!orderMap[defectId]) {
@@ -116,10 +114,10 @@ export default function GarmentDamageMarker({
   const totalMarks = Object.keys(damagePositions).length + Object.keys(defectPositions).length;
 
   const handleMarkerClick = (type, id) => {
-    if (type === 'damage' && onSelectDamage && damageMarkable[id]) {
+    if (type === 'damage' && onSelectDamage) {
       onSelectDamage(id);
     }
-    if (type === 'defect' && onSelectDefect && defectMarkable[id]) {
+    if (type === 'defect' && onSelectDefect) {
       onSelectDefect(id);
     }
   };
@@ -133,8 +131,6 @@ export default function GarmentDamageMarker({
           damagePositions={damagePositions}
           defectPositions={defectPositions}
           isWholeProductMarker={isWholeMarker}
-          damageMarkable={damageMarkable}
-          defectMarkable={defectMarkable}
           removeDamage={(e, idx) => {
             e.stopPropagation();
             setDamagePositions((p) => {

--- a/src/components/order/damage-marker/MarkerList.jsx
+++ b/src/components/order/damage-marker/MarkerList.jsx
@@ -44,9 +44,7 @@ export default function MarkerList({
       order: markerSelectionOrder[`damage-${idx}`],
       label: d === 'tear' ? 'Reva' : d,
       pos: damagePositions[idx],
-      markable: damageMarkable[idx],
-    }))
-    .filter((e) => e.markable);
+    }));
 
   const defectEntries = Object.entries(product.otherIssues || {})
     .filter(([, on]) => on)
@@ -57,9 +55,7 @@ export default function MarkerList({
       order: markerSelectionOrder[id],
       label: getDefectLabel(id),
       pos: defectPositions[id],
-      markable: defectMarkable[id],
-    }))
-    .filter((e) => e.markable);
+    }));
 
   const entries = [...damageEntries, ...defectEntries].sort((a, b) => {
     const orderA = a.order ?? Infinity;
@@ -75,7 +71,6 @@ export default function MarkerList({
       <h5 className="text-sm font-medium mb-1">Valda markeringar:</h5>
       <div className="flex flex-wrap gap-2">
         {entries.map((e) => {
-          const markable = !!e.markable;
           const selected =
             (e.type === 'damage' && selectedDamageIndex === e.id) ||
             (e.type === 'defect' && selectedDefectId === e.id);
@@ -89,12 +84,11 @@ export default function MarkerList({
               role="button"
               tabIndex={0}
               onClick={() => {
-                if (!markable) return;
                 e.type === 'damage'
                   ? onSelectDamage && onSelectDamage(e.id)
                   : onSelectDefect && onSelectDefect(e.id);
               }}
-              className={`flex items-center border rounded-full px-3 py-1 text-xs ${markable ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'} ${baseClasses} ${selected ? 'ring-2 ring-blue-500' : ''}`}
+              className={`flex items-center border rounded-full px-3 py-1 text-xs cursor-pointer ${baseClasses} ${selected ? 'ring-2 ring-blue-500' : ''}`}
             >
               <span className="flex items-center">
                 <span

--- a/src/components/order/damage-marker/MarkerList.jsx
+++ b/src/components/order/damage-marker/MarkerList.jsx
@@ -44,7 +44,9 @@ export default function MarkerList({
       order: markerSelectionOrder[`damage-${idx}`],
       label: d === 'tear' ? 'Reva' : d,
       pos: damagePositions[idx],
-    }));
+      markable: damageMarkable[idx],
+    }))
+    .filter((e) => e.markable);
 
   const defectEntries = Object.entries(product.otherIssues || {})
     .filter(([, on]) => on)
@@ -55,7 +57,9 @@ export default function MarkerList({
       order: markerSelectionOrder[id],
       label: getDefectLabel(id),
       pos: defectPositions[id],
-    }));
+      markable: defectMarkable[id],
+    }))
+    .filter((e) => e.markable);
 
   const entries = [...damageEntries, ...defectEntries].sort((a, b) => {
     const orderA = a.order ?? Infinity;
@@ -71,6 +75,7 @@ export default function MarkerList({
       <h5 className="text-sm font-medium mb-1">Valda markeringar:</h5>
       <div className="flex flex-wrap gap-2">
         {entries.map((e) => {
+          const markable = !!e.markable;
           const selected =
             (e.type === 'damage' && selectedDamageIndex === e.id) ||
             (e.type === 'defect' && selectedDefectId === e.id);
@@ -84,11 +89,12 @@ export default function MarkerList({
               role="button"
               tabIndex={0}
               onClick={() => {
+                if (!markable) return;
                 e.type === 'damage'
                   ? onSelectDamage && onSelectDamage(e.id)
                   : onSelectDefect && onSelectDefect(e.id);
               }}
-              className={`flex items-center border rounded-full px-3 py-1 text-xs cursor-pointer ${baseClasses} ${selected ? 'ring-2 ring-blue-500' : ''}`}
+              className={`flex items-center border rounded-full px-3 py-1 text-xs ${markable ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'} ${baseClasses} ${selected ? 'ring-2 ring-blue-500' : ''}`}
             >
               <span className="flex items-center">
                 <span


### PR DESCRIPTION
## Summary
- enlarge modal close button
- disallow disabling markers and simplify marker logic
- add required attributes to select elements
- increase padding on selects so their arrows aren't flush with the edge

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438fb50880832c83d4eed41ebda93a