### PR TITLE
Add close buttons and hide empty price summary

### DIFF
--- a/src/components/order/ConfirmationStep.jsx
+++ b/src/components/order/ConfirmationStep.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import { DialogClose } from '../../ui/dialog.jsx';
 
 export default function ConfirmationStep({ resetForm, products = [], discount = 0 }) {
   return (
     <div className="p-8 flex flex-col items-center space-y-4">
-      <h2 className="text-2xl font-bold text-center mb-2">Tack för din beställning!</h2>
+      <div className="flex items-center w-full mb-2">
+        <h2 className="text-2xl font-bold text-center flex-1">Tack för din beställning!</h2>
+        <DialogClose className="text-xl" />
+      </div>
       <p className="text-center text-gray-700 mb-4">
         Din beställning är nu mottagen och vi har skickat en bekräftelse till din e-postadress.
       </p>

--- a/src/components/order/OrderInformationStep.jsx
+++ b/src/components/order/OrderInformationStep.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PriceSummary from '../order/PriceSummary.jsx';
+import PriceSummary, { calculateSummary } from '../order/PriceSummary.jsx';
 import t from '../../i18n.js';
 import { DialogClose } from '../../ui/dialog.jsx';
 
@@ -24,6 +24,8 @@ export default function OrderInformationStep({
     e.preventDefault();
     nextStep && nextStep();
   };
+
+  const { total } = calculateSummary(products);
 
   return (
     <div>
@@ -304,7 +306,7 @@ export default function OrderInformationStep({
           )}
         </div>
 
-        {products.some(p => p.type) && (
+        {products.some(p => p.type) && total > 0 && (
           <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg">
             <h3 className="text-lg font-medium mb-3">{t('thirdStep.summary')}</h3>
             <PriceSummary products={products} />

--- a/src/components/order/PriceSummary.jsx
+++ b/src/components/order/PriceSummary.jsx
@@ -10,7 +10,7 @@ const getPrice = (pricing = {}, count) => {
   return pricing['1'] || 0;
 };
 
-export default function PriceSummary({ products = [], discount = 0 }) {
+export function calculateSummary(products = [], discount = 0) {
   const productTotals = products.map((p) => {
     const category = config.productCategories.find((c) => c.id === p.type);
     let subtotal = 0;
@@ -45,6 +45,13 @@ export default function PriceSummary({ products = [], discount = 0 }) {
   const subTotal = productTotals.reduce((sum, p) => sum + p.subtotal, 0);
   const discountAmount = Math.round(subTotal * (discount / 100));
   const total = subTotal - discountAmount;
+
+  return { productTotals, subTotal, discountAmount, total };
+}
+
+export default function PriceSummary({ products = [], discount = 0 }) {
+  const { productTotals, subTotal, discountAmount, total } =
+    calculateSummary(products, discount);
 
   return (
     <div className="space-y-4">

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -73,6 +73,23 @@ export default function ProductCard({ product, onUpdate }) {
     }
   }, [product.type, category, product.images]);
 
+  // When returning to this step, reopen the marker editor if there are
+  // existing markings stored in the product details so they remain editable.
+  useEffect(() => {
+    const hasDamageMarks = product.damages?.some(
+      (_, idx) => product.damageDetails?.[`damage-${idx}`]?.position
+    );
+    const hasDefectMarks = Object.entries(product.otherIssues || {}).some(
+      ([id, active]) =>
+        active && product.defectDetails?.[id]?.position !== undefined
+    );
+    if ((hasDamageMarks || hasDefectMarks) && !markingOpen) {
+      setMarkingOpen(true);
+    }
+    // intentionally run only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     const dMark = {};
     product.damages.forEach((id, idx) => {

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -55,21 +55,23 @@ export default function ProductCard({ product, onUpdate }) {
     }
   }, [product.damageCount]);
 
-  // This useEffect ensures the correct images are loaded when the product type changes.
+  // Ensure default images are only set if none are saved for this product.
   useEffect(() => {
-    if (product.type && category) {
-      const firstDamageWithImages = category.damages.find(d => d.picturesToBeMarked && d.picturesToBeMarked.length > 0);
-      if(firstDamageWithImages) {
-          const pics = firstDamageWithImages.picturesToBeMarked;
-          updateField('images', {
-              front: pics[0] || null,
-              back: pics[1] || pics[0] || null,
-              left: pics[2] || pics[0] || null,
-              right: pics[3] || pics[0] || null,
-          });
+    if (product.type && category && !product.images) {
+      const firstDamageWithImages = category.damages.find(
+        (d) => d.picturesToBeMarked && d.picturesToBeMarked.length > 0
+      );
+      if (firstDamageWithImages) {
+        const pics = firstDamageWithImages.picturesToBeMarked;
+        updateField('images', {
+          front: pics[0] || null,
+          back: pics[1] || pics[0] || null,
+          left: pics[2] || pics[0] || null,
+          right: pics[3] || pics[0] || null,
+        });
       }
     }
-  }, [product.type, category]);
+  }, [product.type, category, product.images]);
 
   useEffect(() => {
     const dMark = {};

--- a/src/components/order/ProductSelectionStep.jsx
+++ b/src/components/order/ProductSelectionStep.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ProductQuantitySelector from './ProductQuantitySelector';
 import ProductCard from './ProductCard';
-import PriceSummary from './PriceSummary';
+import PriceSummary, { calculateSummary } from './PriceSummary';
+import { DialogClose } from '../../ui/dialog.jsx';
 import t from '../../i18n.js';
 
 export default function ProductSelectionStep({
@@ -49,10 +50,17 @@ export default function ProductSelectionStep({
     );
   };
 
+  const { total } = calculateSummary(products);
+
   return (
     <div className="space-y-4">
       <div className="space-y-4 mb-6">
-        <h2 className="text-xl md:text-2xl font-bold">{t('firstStep.title')}</h2>
+        <div className="flex items-center">
+          <h2 className="text-xl md:text-2xl font-bold flex-1">
+            {t('firstStep.title')}
+          </h2>
+          <DialogClose className="text-xl" />
+        </div>
         <p>{t('firstStep.instruction')}</p>
         <p className="text-sm text-gray-700">{t('firstStep.reminder')}</p>
         <ProductQuantitySelector
@@ -64,7 +72,7 @@ export default function ProductSelectionStep({
       {products.map(p => (
         <ProductCard key={p.id} product={p} onUpdate={updateProduct} />
       ))}
-      {products.some(p => p.type) && (
+      {products.some(p => p.type) && total > 0 && (
         <div className="bg-[hsl(var(--light-purple))] p-4 rounded-lg mb-6">
           <h3 className="text-lg font-medium mb-3">{t('firstStep.summary')}</h3>
           <PriceSummary products={products} />


### PR DESCRIPTION
## Summary
- export `calculateSummary` from `PriceSummary` and use it in steps
- hide summary sections when the total price is zero
- add `DialogClose` buttons to all steps

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dfc9bd7c832cb36eaff1859b4ac1