### PR TITLE
Fix marker persistence when navigating back

### DIFF
--- a/src/components/order/EmployeeOwnershipFields.jsx
+++ b/src/components/order/EmployeeOwnershipFields.jsx
@@ -31,6 +31,7 @@ export default function EmployeeOwnershipFields({ product, onUpdate, onFieldBlur
               value={product.employeeName}
               onChange={(e) => onUpdate('employeeName', e.target.value)}
               onBlur={() => onFieldBlur && onFieldBlur(fieldPrefix + 'employeeName')}
+              required={product.isEmployeeOwned}
               className={`w-full h-10 rounded border px-3 ${fieldError(fieldPrefix + 'employeeName') ? 'border-red-500' : 'border-gray-300'}`}
             />
             {fieldError(fieldPrefix + 'employeeName') && (
@@ -44,6 +45,7 @@ export default function EmployeeOwnershipFields({ product, onUpdate, onFieldBlur
               value={product.employeeDepartment}
               onChange={(e) => onUpdate('employeeDepartment', e.target.value)}
               onBlur={() => onFieldBlur && onFieldBlur(fieldPrefix + 'employeeDepartment')}
+              required={product.isEmployeeOwned}
               className={`w-full h-10 rounded border px-3 ${fieldError(fieldPrefix + 'employeeDepartment') ? 'border-red-500' : 'border-gray-300'}`}
             />
             {fieldError(fieldPrefix + 'employeeDepartment') && (

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -83,12 +83,15 @@ export default function ProductCard({ product, onUpdate }) {
       ([id, active]) =>
         active && product.defectDetails?.[id]?.position !== undefined
     );
-    if ((hasDamageMarks || hasDefectMarks) && !markingOpen) {
+    if (hasDamageMarks || hasDefectMarks) {
       setMarkingOpen(true);
     }
-    // intentionally run only on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [
+    product.damages,
+    product.damageDetails,
+    product.otherIssues,
+    product.defectDetails,
+  ]);
 
   useEffect(() => {
     const dMark = {};


### PR DESCRIPTION
## Summary
- keep damage marker editor open whenever markings exist
- require employee ownership fields when employee-owned product is selected

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843ed6b94d4832c8a1893216774662a