### PR TITLE
add required marker validation

### DIFF
--- a/src/components/OrderForm.jsx
+++ b/src/components/OrderForm.jsx
@@ -19,6 +19,7 @@ const createEmptyProduct = (id) => ({
   employeeDepartment: '',
   damageErrors: {},
   damageOptionErrors: {},
+  markerError: undefined,
 });
 
 export default function OrderForm({ prefilledData = null, scrollRef }) {
@@ -63,6 +64,7 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
 
         const damageErrors = {};
         const damageOptionErrors = {};
+        let markerError;
         if (p.damageCount <= 0) {
           damageErrors[0] = 'Obligatoriskt';
           valid = false;
@@ -81,8 +83,30 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
                   valid = false;
                 }
               }
+              if (damage?.markedOnPicture) {
+                const pos = p.damageDetails?.[`damage-${i}`]?.position;
+                if (!pos) {
+                  markerError = 'Obligatoriskt';
+                  valid = false;
+                }
+              }
             }
           }
+        }
+
+        if (p.otherIssues && category) {
+          Object.entries(p.otherIssues).forEach(([id, active]) => {
+            if (active) {
+              const defect = category.defects.find((d) => d.id === id);
+              if (defect?.markedOnPicture) {
+                const pos = p.defectDetails?.[id]?.position;
+                if (!pos) {
+                  markerError = 'Obligatoriskt';
+                  valid = false;
+                }
+              }
+            }
+          });
         }
 
         return {
@@ -94,6 +118,7 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
           typeError,
           damageErrors,
           damageOptionErrors,
+          markerError,
         };
       })
     );
@@ -104,6 +129,7 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
             const typeError = p.type ? undefined : 'Obligatoriskt';
             const damageErrors = {};
             const damageOptionErrors = {};
+            let markerError;
             if (p.damageCount <= 0) {
               damageErrors[0] = 'Obligatoriskt';
             } else {
@@ -117,10 +143,28 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
                     const opt = p.damageDetails?.[`damage-${i}`]?.optionId;
                     if (!opt) damageOptionErrors[i] = 'Obligatoriskt';
                   }
+                  if (damage?.markedOnPicture) {
+                    const pos = p.damageDetails?.[`damage-${i}`]?.position;
+                    if (!pos) markerError = 'Obligatoriskt';
+                  }
                 }
               }
             }
-            return { ...p, typeError, damageErrors, damageOptionErrors };
+            if (p.otherIssues) {
+              const category = config.productCategories.find((c) => c.id === p.type);
+              if (category) {
+                Object.entries(p.otherIssues).forEach(([id, active]) => {
+                  if (active) {
+                    const defect = category.defects.find((d) => d.id === id);
+                    if (defect?.markedOnPicture) {
+                      const pos = p.defectDetails?.[id]?.position;
+                      if (!pos) markerError = 'Obligatoriskt';
+                    }
+                  }
+                });
+              }
+            }
+            return { ...p, typeError, damageErrors, damageOptionErrors, markerError };
           })
         );
       }

--- a/src/components/OrderForm.jsx
+++ b/src/components/OrderForm.jsx
@@ -65,6 +65,7 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
         const damageErrors = {};
         const damageOptionErrors = {};
         let markerError;
+        const category = config.productCategories.find((c) => c.id === p.type);
         if (p.damageCount <= 0) {
           damageErrors[0] = 'Obligatoriskt';
           valid = false;
@@ -74,7 +75,6 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
               damageErrors[i] = 'Obligatoriskt';
               valid = false;
             } else {
-              const category = config.productCategories.find((c) => c.id === p.type);
               const damage = category?.damages.find((d) => d.id === p.damages[i]);
               if (damage?.options?.length) {
                 const opt = p.damageDetails?.[`damage-${i}`]?.optionId;

--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -244,6 +244,9 @@ export default function ProductCard({ product, onUpdate }) {
               />
             </div>
           )}
+        {product.markerError && (
+          <p className="text-sm text-red-500 mt-1">{product.markerError}</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/order/ProductSelectionStep.jsx
+++ b/src/components/order/ProductSelectionStep.jsx
@@ -32,6 +32,7 @@ export default function ProductSelectionStep({
         employeeDepartment: '',
         damageErrors: {},
         damageOptionErrors: {},
+        markerError: undefined,
       },
     ];
     setProducts(newProducts);


### PR DESCRIPTION
## Summary
- add `markerError` property to products to track missing damage marks
- validate that required damage and defect marks are placed
- surface missing mark error in `ProductCard`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843facd7bb4832cb432b392928dee06