### PR TITLE
Fix defect label display

### DIFF
--- a/src/components/order/ProductCard.jsx
+++ b/src/components/order/ProductCard.jsx
@@ -149,6 +149,15 @@ export default function ProductCard({ product, onUpdate }) {
     issues[id] = !issues[id];
     updateField('otherIssues', issues);
 
+    const labels = { ...(product.defectLabels || {}) };
+    if (issues[id]) {
+      const defectObj = DEFECT_OPTIONS.find((d) => d.id === id);
+      if (defectObj) labels[id] = defectObj.label;
+    } else {
+      delete labels[id];
+    }
+    updateField('defectLabels', labels);
+
     if (issues[id]) {
       const defectObj = DEFECT_OPTIONS.find((d) => d.id === id);
       if (defectObj?.markedOnPicture) {


### PR DESCRIPTION
## Summary
- store selected defect labels on toggle so marker list shows proper names

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440c55b8c8832cbd7f04068a7f2c5f