### PR TITLE
Add email preview step

### DIFF
--- a/src/components/OrderForm.jsx
+++ b/src/components/OrderForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import ProductSelectionStep from './order/ProductSelectionStep.jsx';
 import OrderInformationStep from './order/OrderInformationStep.jsx';
 import ConfirmationStep from './order/ConfirmationStep.jsx';
+import FifthStep from './order/FifthStep.jsx';
 import config from '../setup/config.js';
 import t from '../setup/i18n.js';
 
@@ -217,9 +218,21 @@ export default function OrderForm({ prefilledData = null, scrollRef }) {
     setOrderInfo((prev) => ({ ...prev, [field]: value }));
   };
 
-  return step === 2 ? (
+  return step === 3 ? (
     <div ref={containerRef} className="order-form-container">
-      <ConfirmationStep resetForm={resetForm} products={products} />
+      <FifthStep
+        orderInfo={orderInfo}
+        products={products}
+        prevStep={() => setStep(2)}
+      />
+    </div>
+  ) : step === 2 ? (
+    <div ref={containerRef} className="order-form-container">
+      <ConfirmationStep
+        resetForm={resetForm}
+        products={products}
+        onPreview={() => setStep(3)}
+      />
     </div>
   ) : (
     <div ref={containerRef} className="order-form-inner">

--- a/src/components/order/ConfirmationStep.jsx
+++ b/src/components/order/ConfirmationStep.jsx
@@ -2,7 +2,12 @@ import React, { useContext } from 'react';
 import { DialogClose, DialogContext } from './ui/Dialog.jsx';
 import t from '../../setup/i18n.js';
 
-export default function ConfirmationStep({ resetForm, products = [], discount = 0 }) {
+export default function ConfirmationStep({
+  resetForm,
+  products = [],
+  discount = 0,
+  onPreview,
+}) {
   const dialogCtx = useContext(DialogContext);
   return (
     <div className="confirm-container">
@@ -32,6 +37,13 @@ export default function ConfirmationStep({ resetForm, products = [], discount = 
           className="secondary-button"
         >
           {t('fourthStep.additionalOrder')}
+        </button>
+        <button
+          type="button"
+          onClick={onPreview}
+          className="secondary-button"
+        >
+          {t('fourthStep.previewEmail')}
         </button>
         <button
           type="button"

--- a/src/components/order/FifthStep.jsx
+++ b/src/components/order/FifthStep.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import config from '../../setup/config.js';
+import t, { localize } from '../../setup/i18n.js';
+import PriceSummary, { calculateSummary } from './PriceSummary.jsx';
+
+export default function FifthStep({ orderInfo = {}, products = [], prevStep }) {
+  const { total } = calculateSummary(products);
+  const et = config.emailTemplate || {};
+
+  return (
+    <div className="email-preview-container">
+      <h1 className="email-company">{localize(et.header?.company_name)}</h1>
+      <h2 className="email-title">{localize(et.main_title)}</h2>
+      <p>{localize(et.intro?.thank_you)}</p>
+      <p>{localize(et.intro?.summary_text)}</p>
+
+      <div className="email-section">
+        <h3 className="email-section-title">
+          {localize(et.sections?.order_information?.title)}
+        </h3>
+        <p>
+          {localize(et.sections?.order_information?.fields?.customer_number)}{' '}
+          {orderInfo.customerNumber || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.order_information?.fields?.company_name)}{' '}
+          {orderInfo.companyName || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.order_information?.fields?.orderer_name)}{' '}
+          {orderInfo.ordererName || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.order_information?.fields?.phone)} {orderInfo.phone || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.order_information?.fields?.email)} {orderInfo.email || '-'}
+        </p>
+      </div>
+
+      <div className="email-section">
+        <h3 className="email-section-title">
+          {localize(et.sections?.billing_address?.title)}
+        </h3>
+        <p>
+          {localize(et.sections?.billing_address?.fields?.company_name)}{' '}
+          {orderInfo.billingCompanyName || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.billing_address?.fields?.street_address)}{' '}
+          {orderInfo.billingStreet || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.billing_address?.fields?.postal_code)}{' '}
+          {orderInfo.billingZipCode || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.billing_address?.fields?.city)} {orderInfo.billingCity || '-'}
+        </p>
+      </div>
+
+      <div className="email-section">
+        <h3 className="email-section-title">
+          {localize(et.sections?.pickup_address?.title)}
+        </h3>
+        <p>
+          {localize(et.sections?.pickup_address?.fields?.company_name)}{' '}
+          {orderInfo.pickupCompanyName || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.pickup_address?.fields?.street_address)}{' '}
+          {orderInfo.pickupStreet || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.pickup_address?.fields?.postal_code)}{' '}
+          {orderInfo.pickupZipCode || '-'}
+        </p>
+        <p>
+          {localize(et.sections?.pickup_address?.fields?.city)} {orderInfo.pickupCity || '-'}
+        </p>
+      </div>
+
+      {!orderInfo.usePickupAddressForDelivery && (
+        <div className="email-section">
+          <h3 className="email-section-title">
+            {localize(et.sections?.delivery_address?.title)}
+          </h3>
+          <p>
+            {localize(et.sections?.delivery_address?.fields?.company_name)}{' '}
+            {orderInfo.deliveryCompanyName || '-'}
+          </p>
+          <p>
+            {localize(et.sections?.delivery_address?.fields?.street_address)}{' '}
+            {orderInfo.deliveryStreet || '-'}
+          </p>
+          <p>
+            {localize(et.sections?.delivery_address?.fields?.postal_code)}{' '}
+            {orderInfo.deliveryZipCode || '-'}
+          </p>
+          <p>
+            {localize(et.sections?.delivery_address?.fields?.city)}{' '}
+            {orderInfo.deliveryCity || '-'}
+          </p>
+        </div>
+      )}
+
+      <div className="email-section">
+        <h3 className="email-section-title">
+          {localize(et.sections?.products?.title)}
+        </h3>
+        <PriceSummary products={products} />
+      </div>
+
+      <div className="email-footer">
+        <strong>
+          {localize(et.footer?.total_cost)} {total} {localize(et.footer?.currency)}
+        </strong>
+      </div>
+
+      <div className="email-actions">
+        <button type="button" onClick={prevStep} className="secondary-button">
+          {t('fifthStep.back')}
+        </button>
+        <button type="button" className="primary-button">
+          {t('fifthStep.sendEmail')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/order.css
+++ b/src/styles/order.css
@@ -1034,3 +1034,30 @@
   margin-top: 0.25rem;
   margin-bottom: 1rem;
 }
+
+.email-preview-container {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+.email-company {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+.email-section {
+  width: 100%;
+}
+.email-section-title {
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+.email-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add FifthStep component to display preview of the e‑mail
- let ConfirmationStep open this step
- update OrderForm logic for the new step
- style the e‑mail preview

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684479b0f668832c80cec87f7274c039